### PR TITLE
Update zsh completion scripts

### DIFF
--- a/list-collects.rkt
+++ b/list-collects.rkt
@@ -22,7 +22,26 @@
                               (current-library-collection-paths))])
          (add-directory-collections c s))]
       [(path? l)
+       ;; TODO: this case generates false-positives for Zsh. For example, say
+       ;; the package named PACK is linked at ~/code/PACK as a "top-level
+       ;; collection" (list "PACK" "~/code/PACK"); then the below code will
+       ;; typically result in ~/code ending up in Zsh's list of prefixes to
+       ;; complete from. But ~/code probably contains more than just Racket
+       ;; packages! In the worst case, a package's info.rkt might specify a
+       ;; different name for the collection than either of PACK or ~/code/PACK
+       ;; (in which case completion can't generate matches) so that the link is,
+       ;; e.g., (list "COLLECT" "~/code/PACK"). Ideally we'd spit out a list of
+       ;; collection names rather than generate a list of directory prefixes for
+       ;; Zsh and then rely on Zsh traversing the filesystem.
+       ;;
+       ;; "Root" collections (list 'root <path>) don't appear to have this
+       ;; problem. See "Collection Links"
        (let ([s (for*/fold ([s s]) ([c (in-list (links #:file l #:root? #f #:with-path? #t))])
+                  ;; TODO: see above. Here we throw away any root collection
+                  ;; names. Because we don't go through
+                  ;; add-directory-collections, either, we end up adding
+                  ;; ~/code/PACK to the list of candidates, which gets turned
+                  ;; into ~/code for Zsh.
                   (hash-set s (cdr c) #t))])
          (for*/fold ([s s]) ([c (in-list (links #:file l #:root? #t))])
            (add-directory-collections c s)))]

--- a/list-collects.rkt
+++ b/list-collects.rkt
@@ -2,7 +2,7 @@
 
 (provide get-top-level-collection-paths)
 
-(require racket/string racket/list racket/path setup/dirs setup/link)
+(require racket/list racket/path setup/link)
 
 (define (add-directory-collections c s)
   (if (directory-exists? c)
@@ -35,7 +35,7 @@
   (define shell (getenv var))
   (cond [(equal? shell "bash")
          (for ([p (get-top-level-collection-paths)])
-           (define-values [base name dir?] (split-path p))
+           (define-values [_base name _dir?] (split-path p))
            (displayln name))]
         [(equal? shell "zsh")
          (for-each displayln

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -559,16 +559,38 @@ _raco_cmd_pkg() {
   fi
 }
 
+INSTALL_UPDATE_ARGS=(
+  '(-t --type)'{-t,--type}'[Specify type of source, instead of inferred]:type:(file dir file-url dir-url git git-url github name)'
+  '(-n --name)'{-n,--name}'[Specify name of package, instead of inferred; makes sense only when a single pkg-source is given]:name: '
+  '(--checksum)'--checksum'[Checksum of package, either expected or selected; makes sense only when a single pkg-source is given]:checksum: '
+  '(--deps --auto)'--deps'[Specify the behavior for uninstalled dependencies]:mode:(fail force search-ask search-auto)'
+  '(--deps --auto)'--auto'[Shorthand for `--deps search-auto'\'']'
+  '(--update-deps)'--update-deps'[For `search-ask'\'' or `search-auto'\'', also update dependencies]'
+  '(--ignore-implies)'--ignore-implies'[When updating, treat `implies'\'' like other dependencies]'
+  '(--scope -i --installation -u --user --scope-dir)'--scope'[Select package scope]:scope:(installation user)'
+  '(--scope -i --installation -u --user --scope-dir)'{-i,--installation}'[Shorthand for `--scope installation'\'']'
+  '(--scope -i --installation -u --user --scope-dir)'{-u,--user}'[Shorthand for `--scope user'\'']'
+  '(--scope -i --installation -u --user --scope-dir)'--scope-dir'[Select package scope <dir>]:scope:_files -/'
+  '*'--catalog'[Use instead of configured catalogs]:catalog: '
+  '(--all-platforms)'--all-platforms'[Follow package dependencies for all platforms]'
+  '(--force)'--force'[Ignore conflicts]'
+  '(--ignore-checksums)'--ignore-checksums'[Ignore checksums]'
+  '(--strict-doc-conflicts)'--strict-doc-conflicts'[Report doc-name conflicts, even for user scope]'
+  '(--no-cache)'--no-cache'[Disable download cache]'
+  '(--multi-clone)'--multi-clone'[Specify treatment of multiple clones of a repository]:mode:(convert ask fail force)'
+  '(--pull)'--pull'[Specify `git pull'\'' mode for repository clones]:mode:(ff-only try rebase)'
+  '(--dry-run)'--dry-run'[Don'\''t actually change package installation]'
+  '(--no-setup)'--no-setup'[Don'\''t `raco setup` after changing packages (usually a bad idea)]'
+  '(-D --no-docs)'{-D,--no-docs}'[Do not compile .scrbl files and do not build documentation]'
+  '(--recompile-only)'--recompile-only'[Expect built packages, possibly machine-independent]'
+  '(-j --jobs)'{-j,--jobs}'[Setup with N parallel jobs]:cores: '
+  '(--batch)'--batch'[Disable interactive mode and all prompts]'
+  '(--no-trash)'--no-trash'[Delete uninstalled/updated, instead of moving to a trash folder]'
+)
+
 _racket_self_test 'raco pkg install:2252657386'
 _raco_cmd_pkg_install() {
   local specs=(
-    '(-t --type)'{-t,--type}'[Specify type of source, instead of inferred]:type:(file dir file-url dir-url git git-url github name)'
-    '(-n --name)'{-n,--name}'[Specify name of package, instead of inferred; makes sense only when a single pkg-source is given]:name: '
-    '(--checksum)'--checksum'[Checksum of package, either expected or selected; makes sense only when a single pkg-source is given]:checksum: '
-    '(--deps --auto)'--deps'[Specify the behavior for uninstalled dependencies]:mode:(fail force search-ask search-auto)'
-    '(--deps --auto)'--auto'[Shorthand for `--deps search-auto'\'']'
-    '(--update-deps)'--update-deps'[For `search-ask'\'' or `search-auto'\'', also update dependencies]'
-    '(--ignore-implies)'--ignore-implies'[When updating, treat `implies'\'' like other dependencies]'
     '(--link --static-link --copy --clone --source --binary --binary-lib)'--link'[Link a directory package source in place (default for a directory)]'
     '(--link --static-link --copy --clone --source --binary --binary-lib)'--static-link'[Link in place, promising collections do not change]'
     '(--link --static-link --copy --clone --source --binary --binary-lib)'--copy'[Treat directory sources the same as other sources]'
@@ -576,31 +598,32 @@ _raco_cmd_pkg_install() {
     '(--link --static-link --copy --clone --source --binary --binary-lib)'--source'[Strip packages'\'' built elements before installing; implies --copy]'
     '(--link --static-link --copy --clone --source --binary --binary-lib)'--binary'[Strip packages'\'' source elements before installing; implies --copy]'
     '(--link --static-link --copy --clone --source --binary --binary-lib)'--binary-lib'[Strip source & documentation before installing; implies --copy]'
-    '(--scope -i --installation -u --user --scope-dir)'--scope'[Select package scope]:scope:(installation user)'
-    '(--scope -i --installation -u --user --scope-dir)'{-i,--installation}'[Shorthand for `--scope installation'\'']'
-    '(--scope -i --installation -u --user --scope-dir)'{-u,--user}'[Shorthand for `--scope user'\'']'
-    '(--scope -i --installation -u --user --scope-dir)'--scope-dir'[Select package scope <dir>]:scope:_files -/'
-    '*'--catalog'[Use instead of configured catalogs]:catalog: '
     '(--skip-installed)'--skip-installed'[Skip a pkg-source if already installed]'
     '(--pkgs)'--pkgs'[Install only the specified packages, even when none are provided]'
-    '(--all-platforms)'--all-platforms'[Follow package dependencies for all platforms]'
-    '(--force)'--force'[Ignore conflicts]'
-    '(--ignore-checksums)'--ignore-checksums'[Ignore checksums]'
-    '(--strict-doc-conflicts)'--strict-doc-conflicts'[Report doc-name conflicts, even for user scope]'
-    '(--no-cache)'--no-cache'[Disable download cache]'
-    '(--multi-clone)'--multi-clone'[Specify treatment of multiple clones of a repository]:mode:(convert ask fail force)'
-    '(--pull)'--pull'[Specify `git pull'\'' mode for repository clones]:mode:(ff-only try rebase)'
-    '(--dry-run)'--dry-run'[Don'\''t actually change package installation]'
-    '(--no-setup)'--no-setup'[Don'\''t `raco setup` after changing packages (usually a bad idea)]'
-    '(-D --no-docs)'{-D,--no-docs}'[Do not compile .scrbl files and do not build documentation]'
-    '(--recompile-only)'--recompile-only'[Expect built packages, possibly machine-independent]'
-    '(-j --jobs)'{-j,--jobs}'[Setup with N parallel jobs]:cores: '
-    '(--batch)'--batch'[Disable interactive mode and all prompts]'
-    '(--no-trash)'--no-trash'[Delete uninstalled/updated, instead of moving to a trash folder]'
     '(--fail-fast)'--fail-fast'[Break `raco setup'\'' when it discovers an error]'
     '*:package source: '
   )
-  _arguments "$RACKET_COMMON[@]" "$specs[@]" && return 0
+  _arguments "$RACKET_COMMON[@]" "$INSTALL_UPDATE_ARGS[@]" "$specs[@]" && return 0
+  _racket_do_state
+}
+
+_racket_self_test 'raco pkg update:1525052410'
+_raco_cmd_pkg_update() {
+  local specs=(
+    '(-a --all)'{-a,--all}'[Update all packages if no pkg-source is given]'
+    '(--lookup)'--lookup'[When pkg-source is a name, get source from a catalog instead of using the currently installed source; unclones or combines with `--clone'\'']'
+    '(--link --static-link --copy --clone --unclone --source --binary --binary-lib)'--link'[Link a directory package source in place (default for a directory)]'
+    '(--link --static-link --copy --clone --unclone --source --binary --binary-lib)'--static-link'[Link in place, promising collections do not change]'
+    '(--link --static-link --copy --clone --unclone --source --binary --binary-lib)'--copy'[Treat directory sources the same as other sources]'
+    '(--link --static-link --copy --clone --unclone --source --binary --binary-lib)'--clone'[Clone Git and GitHub package sources and link]:clone directory: '
+    '(--link --static-link --copy --clone --unclone --source --binary --binary-lib)'--unclone'[Unclones when currently a clone; alias for --lookup]'
+    '(--link --static-link --copy --clone --unclone --source --binary --binary-lib)'--source'[Strip packages'\'' built elements before installing; implies --copy]'
+    '(--link --static-link --copy --clone --unclone --source --binary --binary-lib)'--binary'[Strip packages'\'' source elements before installing; implies --copy]'
+    '(--link --static-link --copy --clone --unclone --source --binary --binary-lib)'--binary-lib'[Strip source & documentation before installing; implies --copy]'
+    '(--skip-uninstalled)'--skip-uninstalled'[Skip a pkg-source if not installed]'
+    '*:package source: '
+  )
+  _arguments "$RACKET_COMMON[@]" "$INSTALL_UPDATE_ARGS[@]" "$specs[@]" && return 0
   _racket_do_state
 }
 

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -401,11 +401,11 @@ _raco_cmd_ctool() {
   _racket_do_state
 }
 
-_racket_self_test 'raco distribute:1034282712'
+_racket_self_test 'raco distribute:1595797597'
 _raco_cmd_distribute() {
   _arguments "$RACKET_COMMON[@]" \
-    '(--collects-path)'--collects-path'+[Set path as main collects for executables]:collection:->collect' \
-    '*'++collects-copy'+[Add collects in dir to directory]:collection:->collect' \
+    '(--collects-path)'--collects-path'[Set path as main collects for executables]:collection:->collect' \
+    '*'++collects-copy'[Add collects in dir to directory]:collection:->collect' \
     '(-v)'-v'[Verbose mode]' \
     '1:destination-directory:_files -/' \
     '*:executable:_files' \

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -316,23 +316,29 @@ _raco_cmd_scribble() {
   _racket_do_state
 }
 
-_racket_self_test 'raco exe:614832725'
+_racket_self_test 'raco exe:1343818001'
 _raco_cmd_exe() {
   _arguments "$RACKET_COMMON[@]" \
-    '(-o)'-o'+[Write executable as file]:output-executable:_files' \
-    '(--gui)'--gui'+[Generate GUI executable]' \
+    '(-o)'-o'[Write executable as file]:output-executable:_files' \
+    '(--gui)'--gui'[Generate GUI executable]' \
     '(-l --launcher)'{-l,--launcher}'[Generate a launcher]' \
-    '(--collects-path)'--collects-path'+[Set path as main collects for executable]:collection:->collect' \
-    '(--collects-dest)'--collects-dest'+[Write collection code to directory]:directory:_files -/' \
-    '(--ico)'--ico'+[Set Windows icon for executable]:ico-file:_files -g \*.ico' \
-    '(--icns)'--icns'+[Set Mac OS X icon for executable]:icns-file:_files -g \*.icns' \
+    '(--embed-dlls)'--embed-dlls'[On Windows, embed DLLs in the executable]' \
+    '(--config-path)'--config-path'[Set path as configuration directory for executable]:config:_files -/' \
+    '(--collects-path)'--collects-path'[Set path as main collects for executable]:collection:->collect' \
+    '(--collects-dest)'--collects-dest'[Write collection code to directory]:directory:_files -/' \
+    '(--ico)'--ico'[Set Windows icon for executable]:ico-file:_files -g \*.ico' \
+    '(--icns)'--icns'[Set Mac OS X icon for executable]:icns-file:_files -g \*.icns' \
     '(--orig-exe)'--orig-exe'[Use original executable instead of stub]' \
-    '(--3m --cgc)'--3m'[Generate using 3m variant]' \
-    '(--3m --cgc)'--cgc'[Generate using CGC variant]' \
-    '*'++aux'+[Extra executable info (based on aux-file suffix)]:aux-file:_files' \
-    '*'++lib'+[Embed lib in executable]:lib-file:_files' \
-    '*'++exf'+[Add flag to embed in executable]:flag: ' \
-    '*'--exf'+[Remove flag to embed in executable]:flag: ' \
+    '(--3m --cgc --cs)'--3m'[Generate using 3m variant]' \
+    '(--3m --cgc --cs)'--cgc'[Generate using CGC variant]' \
+    '(--3m --cgc --cs)'--cs'[Generate using CS variant]' \
+    '*'++lib'[Embed lib in executable]:lib-file:_files' \
+    '*'++lang'[Embed support for `#lang <lang>'\'' in executable]:lang:->libfile' \
+    '*'++named-lib'[Embed lib with name using prefix]:prefix: :lib-file:_files' \
+    '*'++named-file'[Embed file with name using prefix]:prefix: :file:_files' \
+    '*'++aux'[Extra executable info (based on aux-file suffix)]:aux-file:_files' \
+    '*'++exf'[Add flag to embed in executable]:flag: ' \
+    '*'--exf'[Remove flag to embed in executable]:flag: ' \
     '*'--exf-clear'[Clear flags to embed in executable]' \
     '*'--exf-show'[Show flags to embed in executable]' \
     '(-v)'-v'[Verbose mode]' \

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -348,14 +348,15 @@ _raco_cmd_exe() {
   _racket_do_state
 }
 
-_racket_self_test 'raco make:3358542168'
+_racket_self_test 'raco make:3873989386'
 _raco_cmd_make() {
   _arguments "$RACKET_COMMON[@]" \
-    '(-j)'-j'+[Use N parallel jobs]:cores: ' \
+    '*'-l'[Compile path as a collection-based module path]:path:->libfile' \
+    '(-j)'-j'[Use N parallel jobs]:cores: ' \
     '(--disable-inline)'--disable-inline'[Disable procedure inlining during compilation]' \
     '(--disable-constant)'--disable-constant'[Disable enforcement of module constants]' \
     '(--no-deps)'--no-deps'[Compile immediate files without updating dependencies]' \
-    '(-p --prefix)'{-p,--prefix}'+[Add elaboration-time prefix file for --no-deps]:prefix-file:_files' \
+    '(-p --prefix)'{-p,--prefix}'[Add elaboration-time prefix file for --no-deps]:prefix-file:_files' \
     '(--no-prim)'--no-prim'[Do not assume `scheme'"'"' bindings at top level for --no-deps]' \
     '(-v)'-v'[Verbose mode]' \
     '(--vv)'--vv'[Very verbose mode]' \

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -567,10 +567,6 @@ INSTALL_UPDATE_ARGS=(
   '(--deps --auto)'--auto'[Shorthand for `--deps search-auto'\'']'
   '(--update-deps)'--update-deps'[For `search-ask'\'' or `search-auto'\'', also update dependencies]'
   '(--ignore-implies)'--ignore-implies'[When updating, treat `implies'\'' like other dependencies]'
-  '(--scope -i --installation -u --user --scope-dir)'--scope'[Select package scope]:scope:(installation user)'
-  '(--scope -i --installation -u --user --scope-dir)'{-i,--installation}'[Shorthand for `--scope installation'\'']'
-  '(--scope -i --installation -u --user --scope-dir)'{-u,--user}'[Shorthand for `--scope user'\'']'
-  '(--scope -i --installation -u --user --scope-dir)'--scope-dir'[Select package scope <dir>]:scope:_files -/'
   '*'--catalog'[Use instead of configured catalogs]:catalog: '
   '(--all-platforms)'--all-platforms'[Follow package dependencies for all platforms]'
   '(--force)'--force'[Ignore conflicts]'
@@ -588,6 +584,13 @@ INSTALL_UPDATE_ARGS=(
   '(--no-trash)'--no-trash'[Delete uninstalled/updated, instead of moving to a trash folder]'
 )
 
+SCOPE_ARGS=(
+  '(--scope -i --installation -u --user --scope-dir)'--scope'[Select package scope]:scope:(installation user)'
+  '(--scope -i --installation -u --user --scope-dir)'{-i,--installation}'[Shorthand for `--scope installation'\'']'
+  '(--scope -i --installation -u --user --scope-dir)'{-u,--user}'[Shorthand for `--scope user'\'']'
+  '(--scope -i --installation -u --user --scope-dir)'--scope-dir'[Select package scope <dir>]:scope:_files -/'
+)
+
 _racket_self_test 'raco pkg install:2252657386'
 _raco_cmd_pkg_install() {
   local specs=(
@@ -603,7 +606,7 @@ _raco_cmd_pkg_install() {
     '(--fail-fast)'--fail-fast'[Break `raco setup'\'' when it discovers an error]'
     '*:package source: '
   )
-  _arguments "$RACKET_COMMON[@]" "$INSTALL_UPDATE_ARGS[@]" "$specs[@]" && return 0
+  _arguments "$RACKET_COMMON[@]" "$INSTALL_UPDATE_ARGS[@]" "$SCOPE_ARGS[@]" "$specs[@]" && return 0
   _racket_do_state
 }
 
@@ -623,7 +626,26 @@ _raco_cmd_pkg_update() {
     '(--skip-uninstalled)'--skip-uninstalled'[Skip a pkg-source if not installed]'
     '*:package source: '
   )
-  _arguments "$RACKET_COMMON[@]" "$INSTALL_UPDATE_ARGS[@]" "$specs[@]" && return 0
+  _arguments "$RACKET_COMMON[@]" "$INSTALL_UPDATE_ARGS[@]" "$SCOPE_ARGS[@]" "$specs[@]" && return 0
+  _racket_do_state
+}
+
+_racket_self_test 'raco pkg uninstall:1205341767'
+_raco_cmd_pkg_uninstall() {
+  local specs=(
+    '(--demote)'--demote'[Demote to auto-installed, instead of removing]'
+    '(--force)'--force'[Uninstall even if package has dependents]'
+    '(--auto)'--auto'[Also uninstall auto-installed packages that have no dependents]'
+    '(--dry-run)'--dry-run'[Don'\''t actually change package installation]'
+    '(--no-setup)'--no-setup'[Don'\''t `raco setup` after changing packages (usually a bad idea)]'
+    '(-D --no-docs)'{-D,--no-docs}'[Do not compile .scrbl files and do not build documentation]'
+    '(--recompile-only)'--recompile-only'[Expect built packages, possibly machine-independent]'
+    '(-j --jobs)'{-j,--jobs}'[Setup with N parallel jobs]:cores: '
+    '(--batch)'--batch'[Disable interactive mode and all prompts]'
+    '(--no-trash)'--no-trash'[Delete uninstalled/updated, instead of moving to a trash folder]'
+    '*:package source: '
+  )
+  _arguments "$RACKET_COMMON[@]" "$SCOPE_ARGS[@]" "$specs[@]" && return 0
   _racket_do_state
 }
 

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -668,6 +668,26 @@ _raco_cmd_pkg_new() {
   _racket_do_state
 }
 
+_racket_self_test 'raco pkg show:2737181330'
+_raco_cmd_pkg_show() {
+  local specs=(
+    '(-a --all)'{-a,--all}'[Show auto-installed packages, too]'
+    '(-l --long)'{-l,--long}'[Show full column content]'
+    '(--full-checksum)'--full-checksum'[Show the full checksum]'
+    '(--rx)'--rx'[Treat packages as regular expressions]'
+    '(-d --dir)'{-d,--dir}'[Show the directory where the package is installed]'
+    # like SCOPE_ARGS, but with -v/--version
+    '(--scope -i --installation -u --user --scope-dir -v --version)'--scope'[Select package scope]:scope:(installation user)'
+    '(--scope -i --installation -u --user --scope-dir -v --version)'{-i,--installation}'[Shorthand for `--scope installation'\'']'
+    '(--scope -i --installation -u --user --scope-dir -v --version)'{-u,--user}'[Shorthand for `--scope user'\'']'
+    '(--scope -i --installation -u --user --scope-dir -v --version)'--scope-dir'[Select package scope <dir>]:scope:_files -/'
+    '(--scope -i --installation -u --user --scope-dir -v --version)'{-v,--version}'[Show user-specific for installation version]:version: '
+    '*:package:->installed_package'
+  )
+  _arguments "$RACKET_COMMON[@]" "$specs[@]" && return 0
+  _racket_do_state
+}
+
 _racket_self_test 'raco planet:1582997403'
 _raco_cmd_planet() {
   if (( CURRENT > 2 )); then

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -536,6 +536,29 @@ _raco_cmd_test() {
   _racket_do_state
 }
 
+_racket_self_test 'raco pkg:3232773977'
+_raco_cmd_pkg() {
+  if (( CURRENT > 2 )); then
+    local subcmd="${words[2]}"
+    curcontext="${curcontext%:*:*}:raco-pkg-$subcmd"
+    (( CURRENT-- ))
+    shift words
+    if [[ $subcmd = -(h|-help) ]]; then _message 'no more arguments'
+    elif (( $+functions[_raco_cmd_pkg_$subcmd] )); then _raco_cmd_pkg_$subcmd
+    else _normal
+    fi
+  else
+    local hline
+    local -a cmdlist
+    local pfx='^  raco pkg '
+    cmdlist=(
+      {-h,--help}:'Display help'
+      ${(f)"$(raco pkg | grep "$pfx" | sed -e "s/$pfx"'\([^ ]*\) *\(.*\)/\1:\2/')"}
+    )
+    _describe -t raco-pkg-commands 'raco pkg command' cmdlist
+  fi
+}
+
 _racket_self_test 'raco planet:1582997403'
 _raco_cmd_planet() {
   if (( CURRENT > 2 )); then

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -73,6 +73,14 @@ _racket_read_installed_package() {
   _wanted installed-packages expl installed-package compadd -a packages
 }
 
+_racket_read_migrate_version() {
+  local -a versions
+  versions=(
+    "${(f)$(_racket_call migrate-versions '(require pkg/lib) (for-each displayln (pkg-migrate-available-versions))')}"
+  )
+  _wanted migrate-versions expl migrate-version compadd -a versions
+}
+
 _racket_read_libfile_or_collect() {
   local -a dirs
   dirs=(
@@ -699,7 +707,7 @@ _raco_cmd_pkg_migrate() {
     '(--binary --binary --binary-lib)'--binary'[Strip source elements of the package before installing]'
     '(--binary-lib --binary --binary-lib)'--binary-lib'[Strip source elements and documentation before installing]'
   )
-  _arguments "$RACKET_COMMON[@]" "$COMMON_PKG_ARGS[@]" "$SCOPE_ARGS[@]" "$specs[@]" '1:from version: ' && return 0
+  _arguments "$RACKET_COMMON[@]" "$COMMON_PKG_ARGS[@]" "$SCOPE_ARGS[@]" "$specs[@]" '1:from version:->migrate_version' && return 0
   _racket_do_state
 }
 

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -200,7 +200,7 @@ _raco() {
   fi
 }
 
-_racket_self_test 'raco docs:2277531825'
+_racket_self_test 'raco docs:3335848757'
 _raco_cmd_docs() {
   _arguments "$RACKET_COMMON[@]" \
     '*:search-term: ' \

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -463,9 +463,10 @@ _raco_cmd_unpack() {
   _racket_do_state
 }
 
-_racket_self_test 'raco expand:1935188678'
+_racket_self_test 'raco expand:1013149279'
 _raco_cmd_expand() {
   _arguments "$RACKET_COMMON[@]" \
+    '(--columns -n)'{--columns,-n}'[Format for N columns]:columns: ' \
     '*:source-file:_files' \
   && return 0
   _racket_do_state

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -117,7 +117,7 @@ _racket_self_test() {
 
 ###############################################################################
 
-_racket_self_test 'racket:3785877773:grep -v "Welcome to Racket"'
+_racket_self_test 'racket:2561387185:grep -v "Welcome to Racket"'
 
 RACKET_COMMON=( -C -s -w -S : '(- : *)'{-h,--help}'[Display help]' )
 RACKET_ARGS=( "$RACKET_COMMON[@]" )
@@ -125,12 +125,12 @@ RACKET_ARGS=( "$RACKET_COMMON[@]" )
 # File and expression options:
 RACKET_ARGS+=(
   '*'{-e,--eval}'[Evaluate expression]:expression: '
-  '*'{-f,--load}'+[Load a file]:file:_files'
-  '*'{-t,--require}'+[Require a file]:file:_files'
-  '*'{-l,--lib}'+[Require a library file]:library-file:->libfile'
-  '*'-p'+[Require a planet package]:planet-package: '
-  '(- *)'{-r,--script}'+[Load a script (same as -f F -n F --)]:file:_files'
-  '(- *)'{-u,--require-script}'+[Require a script (same as -tN- F -N F --)]:file:_files'
+  '*'{-f,--load}'[Like -e `(load "FILE")'\'' without printing, or evaluates all from input when <file> is "-"]:file:_files'
+  '*'{-t,--require}'[Like -e `(require (file "FILE"))'\'' and requires a main submodule if any]:file:_files'
+  '*'{-l,--lib}'[Like -e `(require (lib "PATH"))'\'' and requires a main submodule if any]:library-file:->libfile'
+  '*'-p'+[Like -e `(require (planet "PACKAGE"))'\'' and requires a main submodule if any]:planet-package: '
+  '*'{-r,--script}'[Load a script (same as -f FILE -n FILE --)]:file:_files'
+  '*'{-u,--require-script}'[Require a script (same as -tN- FILE)]:file:_files'
   # No need to do `-k' -- it's for internal use by launchers
   '(-m --main)'{-m,--main}'[Call `main'"'"' with command-line arguments]'
 )
@@ -145,21 +145,29 @@ RACKET_ARGS+=(
 
 # Configuration options:
 RACKET_ARGS+=(
+  '(-y --make)'{-y,--make}'[Yes, enable automatic update of compiled files]'
   '(-c --no-compiled)'{-c,--no-compiled}'[Disable loading of compiled files]'
   '(-q --no-init-file)'{-q,--no-init-file}'[Skip loading ~/.racketrc for -i]'
-  '(-I)'-I'+[Set init-lib]:library-file:->libfile'
-  '(-X --collects)'{-X,--collects}'+[Main collects dir ("" disables all)]:directory:_files -/'
-  '*'{-S,--search}'+[More collects dir (after main)]:directory:_files -/'
-  '(-A --addon)'{-A,--addon}'+[Addon directory]:directory:_files -/'
-  '(-R --compiled)'{-A,--addon}'+[Set compiled-file search roots to directory]:directory:_files -/'
-  '(-C --links)'{-C,--links}'+[User-specific collection links file]:file:_files'
+  '(-I)'-I'[Set init-lib]:library-file:->libfile'
+  '(-X --collects)'{-X,--collects}'[Main collects dir ("" disables all)]:directory:_files -/'
+  '*'{-S,--search}'[More collects dir (after main)]:directory:_files -/'
+  '(-G --config)'{-G,--config}'[Main configuration directory]:directory:_files -/'
+  '(-A --addon)'{-A,--addon}'[Addon directory]:directory:_files -/'
   '(-U --no-user-path)'{-U,--no-user-path}'[Ignore user-specific collects, etc.]'
-  '(-N --name)'{-N,--name}'+[Sets (find-system-path '"'"'run-file)]:file:_files'
+  '(-R --compiled)'{-A,--addon}'[Set compiled-file search roots to directory]:directory:_files -/'
+  '(-C --links)'{-C,--links}'[User-specific collection links file]:file:_files'
+  '(-N --name)'{-N,--name}'[Sets (find-system-path '"'"'run-file)]:file:_files'
+  '(-E --exec)'{-E,--exec}'[Sets (find-system-path '"'"'exec-file)]:file:_files'
   '(-j --no-jit)'{-j,--no-jit}'[Disable the just-in-time compiler]'
+  '(-M --compile-any)'{-M,--compile-any}'[Compile to machine-independent form]'
   '(-d --no-delay)'{-d,--no-delay}'[Disable on-demand loading of syntax and code]'
   '(-b --binary)'{-b,--binary}'[Read stdin and write stdout/stderr in binary mode]'
-  '(-W --warn)'{-W,--warn}'+[Set stderr logging level]:log-level:(none fatal error warning info debug)'
-  '(-L --syslog)'{-L,--syslog}'+[Set syslog logging level]:log-level:(none fatal error warning info debug)'
+  '(-W --warn)'{-W,--warn}'[Set stderr logging level]:log-level:(none fatal error warning info debug)'
+  '(-O --stdout)'{-O,--stdout}'[Set stdout logging level]:log-level:(none fatal error warning info debug)'
+  '(-L --syslog)'{-L,--syslog}'[Set syslog logging level]:log-level:(none fatal error warning info debug)'
+  '(--compile-machine)'--compile-machine'[Compile for machine]:machine: '
+  '(--cross-compiler)'--cross-compiler'[Use compiler plugin for machine]:machine: :plugin-dir: '
+  '(--cross-server)'--cross-server'[Drive cross-compiler (as only option)]:machine: :compiler: :lib: '
 )
 
 # Main arguments:

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -490,15 +490,39 @@ _raco_cmd_demodularize() {
   _racket_do_state
 }
 
-_racket_self_test 'raco test:2458495009'
+_racket_self_test 'raco test:2023323379'
 _raco_cmd_test() {
+  local modes='(--collection -c --package -p --lib -l --modules -m)'
   _arguments "$RACKET_COMMON[@]" \
-    '(-s --submodule)'{-s,--submodule}'+[Runs submodule name (defaults to `test'"'"')]:submodule: ' \
+    "$modes"{-c,--collection}'[Interpret arguments as collections]' \
+    "$modes"{-l,--lib}'[Interpret arguments as libraries]' \
+    "$modes"{-p,--package}'[Interpret arguments as packages]' \
+    "$modes"{-m,--modules}'[Interpret arguments as modules (ignore argument unless ".rkt", ".scrbl", or enabled by "info.rkt")]' \
+    '(--drdr)'--drdr'[Configure defaults to imitate DrDr]' \
+    '*'{-s,--submodule}'[Runs submodule name (defaults to `test'"'"')]:submodule: ' \
+    '*'++arg'[Add argument to current-command-line-arguments]:argument: ' \
+    '*'++args'[Adds each whitespace-delimited in args like ++arg]:arguments: ' \
     '(-r --run-if-absent -x --no-run-if-absent)'{-r,--run-if-absent}'[Require module if submodule is absent (on by default)]' \
     '(-r --run-if-absent -x --no-run-if-absent)'{-x,--no-run-if-absent}'[Require nothing if submodule is absent]' \
-    '(-q --quiet)'{-q,--quiet}'+[Suppress `Running ...'"'"' message]' \
-    '(-c --collection)'{-c,--collection}'+[Interpret arguments as collections]' \
-    '(-p --package)'{-p,--package}'+[Interpret arguments as packages]' \
+    '(--first-avail)'--first-avail'[Run only the first available submodule]' \
+    '(--configure-runtime)'--configure-runtime'[Run the `configure-runtime'\'' submodule]' \
+    '(--direct --process --place)'--direct'[Run tests directly (default for a single file)]' \
+    '(--direct --process --place)'--process'[Run tests in separate processes (default for multiple files)]' \
+    '(--direct --process --place)'--place'[Run tests in places]' \
+    '(-j --jobs)'{-j,--jobs}'[Run up to N tests in parallel]:number of tests: ' \
+    '(--timeout)'--timeout'[Set default timeout in seconds]:timeout seconds: ' \
+    '(--fresh-user)'--fresh-user'[Fresh PLTUSERHOME, etc., for each test]' \
+    '(--empty-stdin)'--empty-stdin'[Call program with an empty stdin]' \
+    '(--quiet-program -Q)'{--quiet-program,-Q}'[Quiet the program]' \
+    '(--check-stderr -e)'{--check-stderr,-e}'[Treat stderr output as a test failure]' \
+    '(--deps)'--deps'[If treating arguments as packages, also test dependencies]' \
+    '(--errortrace --make -y)'--errortrace'[Load errortrace before testing]' \
+    '(--errortrace --make -y)'{--make,-y}'[Enable automatic update of compiled files]' \
+    '*'++ignore-stderr'[Enable stderr output that matches #px"pattern"]:pattern: ' \
+    '(-q --quiet)'{-q,--quiet}'+[Suppress `raco test: ...` message]' \
+    '(--heartbeat)'--heartbeat'[Periodically report that a test is still running]' \
+    '(--table, -t)'--table, -t'[Print a summary table]' \
+    '(--output -o)'{--output,-o}'[Save stdout and stderr to file, overwrite if it exists.]:output:_files' \
     '*:source-file-or-directory:_files' \
   && return 0
   _racket_do_state

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -572,6 +572,21 @@ _raco_cmd_pkg() {
   fi
 }
 
+COMMON_PKG_ARGS=(
+  '*'--catalog'[Use instead of configured catalogs]:catalog: '
+  '(--all-platforms)'--all-platforms'[Follow package dependencies for all platforms]'
+  '(--force)'--force'[Ignore conflicts]'
+  '(--ignore-checksums)'--ignore-checksums'[Ignore checksums]'
+  '(--strict-doc-conflicts)'--strict-doc-conflicts'[Report doc-name conflicts, even for user scope]'
+  '(--no-cache)'--no-cache'[Disable download cache]'
+  '(--dry-run)'--dry-run'[Don'\''t actually change package installation]'
+  '(--no-setup)'--no-setup'[Don'\''t `raco setup` after changing packages (usually a bad idea)]'
+  '(-D --no-docs)'{-D,--no-docs}'[Do not compile .scrbl files and do not build documentation]'
+  '(--recompile-only)'--recompile-only'[Expect built packages, possibly machine-independent]'
+  '(-j --jobs)'{-j,--jobs}'[Setup with N parallel jobs]:cores: '
+  '(--batch)'--batch'[Disable interactive mode and all prompts]'
+)
+
 INSTALL_UPDATE_ARGS=(
   '(-t --type)'{-t,--type}'[Specify type of source, instead of inferred]:type:(file dir file-url dir-url git git-url github name)'
   '(-n --name)'{-n,--name}'[Specify name of package, instead of inferred; makes sense only when a single pkg-source is given]:name: '
@@ -580,20 +595,8 @@ INSTALL_UPDATE_ARGS=(
   '(--deps --auto)'--auto'[Shorthand for `--deps search-auto'\'']'
   '(--update-deps)'--update-deps'[For `search-ask'\'' or `search-auto'\'', also update dependencies]'
   '(--ignore-implies)'--ignore-implies'[When updating, treat `implies'\'' like other dependencies]'
-  '*'--catalog'[Use instead of configured catalogs]:catalog: '
-  '(--all-platforms)'--all-platforms'[Follow package dependencies for all platforms]'
-  '(--force)'--force'[Ignore conflicts]'
-  '(--ignore-checksums)'--ignore-checksums'[Ignore checksums]'
-  '(--strict-doc-conflicts)'--strict-doc-conflicts'[Report doc-name conflicts, even for user scope]'
-  '(--no-cache)'--no-cache'[Disable download cache]'
   '(--multi-clone)'--multi-clone'[Specify treatment of multiple clones of a repository]:mode:(convert ask fail force)'
   '(--pull)'--pull'[Specify `git pull'\'' mode for repository clones]:mode:(ff-only try rebase)'
-  '(--dry-run)'--dry-run'[Don'\''t actually change package installation]'
-  '(--no-setup)'--no-setup'[Don'\''t `raco setup` after changing packages (usually a bad idea)]'
-  '(-D --no-docs)'{-D,--no-docs}'[Do not compile .scrbl files and do not build documentation]'
-  '(--recompile-only)'--recompile-only'[Expect built packages, possibly machine-independent]'
-  '(-j --jobs)'{-j,--jobs}'[Setup with N parallel jobs]:cores: '
-  '(--batch)'--batch'[Disable interactive mode and all prompts]'
   '(--no-trash)'--no-trash'[Delete uninstalled/updated, instead of moving to a trash folder]'
 )
 
@@ -619,7 +622,7 @@ _raco_cmd_pkg_install() {
     '(--fail-fast)'--fail-fast'[Break `raco setup'\'' when it discovers an error]'
     '*:package source: '
   )
-  _arguments "$RACKET_COMMON[@]" "$INSTALL_UPDATE_ARGS[@]" "$SCOPE_ARGS[@]" "$specs[@]" && return 0
+  _arguments "$RACKET_COMMON[@]" "$COMMON_PKG_ARGS[@]" "$INSTALL_UPDATE_ARGS[@]" "$SCOPE_ARGS[@]" "$specs[@]" && return 0
   _racket_do_state
 }
 
@@ -639,7 +642,7 @@ _raco_cmd_pkg_update() {
     '(--skip-uninstalled)'--skip-uninstalled'[Skip a pkg-source if not installed]'
     '*:package source:->installed_package'
   )
-  _arguments "$RACKET_COMMON[@]" "$INSTALL_UPDATE_ARGS[@]" "$SCOPE_ARGS[@]" "$specs[@]" && return 0
+  _arguments "$RACKET_COMMON[@]" "$COMMON_PKG_ARGS[@]" "$INSTALL_UPDATE_ARGS[@]" "$SCOPE_ARGS[@]" "$specs[@]" && return 0
   _racket_do_state
 }
 
@@ -685,6 +688,18 @@ _raco_cmd_pkg_show() {
     '*:package:->installed_package'
   )
   _arguments "$RACKET_COMMON[@]" "$specs[@]" && return 0
+  _racket_do_state
+}
+
+_racket_self_test 'raco pkg migrate:2132316292'
+_raco_cmd_pkg_migrate() {
+  local specs=(
+    '(--deps)'--deps'[Specify the behavior for uninstalled dependencies]:mode:(fail force search-ask search-auto)'
+    '(--source --binary --binary-lib)'--source'[Strip built elements of the package before installing]'
+    '(--binary --binary --binary-lib)'--binary'[Strip source elements of the package before installing]'
+    '(--binary-lib --binary --binary-lib)'--binary-lib'[Strip source elements and documentation before installing]'
+  )
+  _arguments "$RACKET_COMMON[@]" "$COMMON_PKG_ARGS[@]" "$SCOPE_ARGS[@]" "$specs[@]" '1:from version: ' && return 0
   _racket_do_state
 }
 

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -208,32 +208,68 @@ _raco_cmd_docs() {
   _racket_do_state
 }
 
-_racket_self_test 'raco setup:2092236815:tail -n +2' # full path for this one
+_racket_self_test 'raco setup:201959535:tail -n +2' # full path for this one
 _raco_cmd_setup() {
+  local collections=(
+    '(--only)'--only'[Set up only specified, even if none]'
+    '(-l)'-l'[Setup specific collections]:*:collection:->collect'
+    '(--pkgs)'--pkgs'[Setup collections in specified packages]:packages: '
+    '*'-P'[Setup specified PLaneT packages only]:owner: :package-name: :major-version: :minor-version: '
+    '(--doc-index)'--doc-index'[Rebuild documentation index along with specified]'
+    '(--tidy)'--tidy'[Clear references to removed items outside of specified]'
+  )
+  local tasks=(
+    '(-c --clean)'{-c,--clean}'[Delete existing compiled files; implies -nxiIFDK]'
+    '(--fast-clean)'--fast-clean'[Like --clean, but non-bootstrapping (can fail)]'
+    '(-n --no-zo)'{-n,--no-zo}'[Do not create .zo files]'
+    '(--trust-zos)'--trust-zos'[Trust existing .zos (use only with prepackaged .zos)]'
+    '(--recompile-only)'--recompile-only'[Fail if compilation must start from source]'
+    '(--sync-docs-only)'--sync-docs-only'[Sync/move documentation, but do not run or render]'
+    '(-x --no-launcher)'{-x,--no-launcher}'[Do not produce launcher programs]'
+    '(-F --no-foreign-libs)'{-F,--no-foreign-libs}'[Do not install foreign libraries]'
+    '(--only-foreign-libs)'--only-foreign-libs'[Disable actions except installing foreign libraries]'
+    '(-i --no-install)'{-i,--no-install}'[Do not call collection-specific pre-installers]'
+    '(-I --no-post-install)'{-I,--no-post-install}'[Do not call collection-specific post-installers]'
+    '(-d --no-info-domain)'{-d,--no-info-domain}'[Do not produce info-domain caches]'
+    '(-D --no-docs)'{-D,--no-docs}'[Do not compile .scrbl files and do not build documentation]'
+    '(--doc-pdf)'--doc-pdf'[Build documentation PDFs to directory]:dir:_files -/'
+    '(-K --no-pkg-deps)'{-K,--no-pkg-deps}'[Do not check package dependencies]'
+    '(--check-pkg-deps)'--check-pkg-deps'[Check package dependencies when collections specified]'
+    '(--fix-pkg-deps)'--fix-pkg-deps'[Auto-repair package-dependency declarations]'
+    '(--unused-pkg-deps)'--unused-pkg-deps'[Check for unused package-dependency declarations]'
+    '(--chain)'--chain'[Select a continuation other than `setup/setup-go`]'
+    '(--boot)'--boot'[Like `--chain`, but use compiled only from <dir>]'
+  )
+  local users=(
+    '(-U,--no-user)'{-U,--no-user}'[Do not setup user-specific collections (implies --no-planet)]'
+    '(--no-planet)'--no-planet'[Do not setup PLaneT packages]'
+    '(--avoid-main)'--avoid-main'[Do not make main-installation files]'
+    '(--force-user-docs)'--force-user-docs'[User-specific documentation even if matching installation]'
+  )
+  local modes=(
+    '(-j --jobs --workers)'{-j,--jobs,--workers}'[Use N parallel jobs]:cores: '
+    '(--places --processes)'--places'[Use places for parallel jobs]'
+    '(--places --processes)'--processes'[Use processes for parallel jobs]'
+    '(-v --verbose)'-v,--verbose'[See names of compiled files and info printfs]'
+    '(-m --make-verbose)'{-m,--make-verbose}'[See make and compiler usual messages]'
+    '(-r --compile-verbose)'{-r,--compile-verbose}'[See make and compiler verbose messages]'
+    '(--mode)'--mode'[Select a compilation mode, such as "errortrace"]:mode:(errortrace)'
+    '(--fail-fast)'--fail-fast'[Trigger a break on the first error]'
+    '(--error-out)'--error-out'[On continuable error, create file and exit as success]:out:_files'
+    '(--error-in)'--error-in'[Check file for report of previous errors]:in:_files'
+    '(-p --pause)'{-p,--pause}'[Pause at the end if there are any errors]'
+  )
+  local archives=(
+    '(--force)'--force'[Treat version mismatches for archives as mere warnings]'
+    '(-a --all-users)'{-a,--all-users}'[Install archives to main (not user-specific) installation]'
+    '(-A)'-A'[Unpack and install .plt archives]:plt archive:_files -g \*.plt'
+  )
   _arguments "$RACKET_COMMON[@]" \
-    '(-c --clean)'{-c,--clean}'[Delete existing compiled files; implies -nxi]' \
-    '(-j --workers)'{-j,--workers}'+[Use N parallel jobs]:cores: ' \
-    '(-n --no-zo)'{-n,--no-zo}'[Do not produce .zo files]' \
-    '(-x --no-launcher)'{-x,--no-launcher}'[Do not produce launcher programs]' \
-    '(-i --no-install)'{-i,--no-install}'[Do not call collection-specific pre-installers]' \
-    '(-I --no-post-install)'{-I,--no-post-install}'[Do not call collection-specific post-installers]' \
-    '(-d --no-info-domain)'{-d,--no-info-domain}'[Do not produce info-domain caches]' \
-    '(-D --no-docs)'{-D,--no-docs}'[Do not compile .scrbl files and do not build documentation]' \
-    '(-U --no-user)'{-U,--no-user}'[Do not setup user-specific collections (implies --no-planet)]' \
-    '(--no-planet)'--no-planet'[Do not setup PLaneT packages]' \
-    '(--avoid-main)'--avoid-main'[Do not make main-installation files]' \
-    '(-v --verbose)'{-v,--verbose}'[See names of compiled files and info printfs]' \
-    '(-m --make-verbose)'{-m,--make-verbose}'[See make and compiler usual messages]' \
-    '(-r --compile-verbose)'{-r,--compile-verbose}'[See make and compiler verbose messages]' \
-    '(--trust-zos)'--trust-zos'[Trust existing .zos (use only with prepackaged .zos)]' \
-    '(-p --pause)'{-p,--pause}'[Pause at the end if there are any errors]' \
-    '(--force)'--force'[Treat version mismatches for archives as mere warnings]' \
-    '(-a --all-users)'{-a,--all-users}'[Install archives to main (not user-specific) installation]' \
-    '(--mode)'--mode'[Select a compilation mode]:log-level:(errortrace)' \
-    '(--doc-pdf)'--doc-pdf'[Write doc PDF to directory]:directory:_files -/' \
-    '(-l)'-l'[Setup specific collections]:*:collection:->collect' \
-    '(-A)'-A'[Unpack and install .plt archives]:plt-archive:_files -g \*.plt' \
-    '*'-P'[Setup specified PLaneT packages only]:owner: :package-name: :major-version: :minor-version: ' \
+    "$collections[@]" \
+    "$tasks[@]" \
+    "$users[@]" \
+    "$modes[@]" \
+    "$archives[@]" \
   && return 0
   _racket_do_state
 }

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -662,6 +662,12 @@ _raco_cmd_pkg_uninstall() {
   _racket_do_state
 }
 
+_racket_self_test 'raco pkg new:2017728815'
+_raco_cmd_pkg_new() {
+  _arguments "$RACKET_COMMON[@]" '1:package: ' && return 0
+  _racket_do_state
+}
+
 _racket_self_test 'raco planet:1582997403'
 _raco_cmd_planet() {
   if (( CURRENT > 2 )); then

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -274,30 +274,43 @@ _raco_cmd_setup() {
   _racket_do_state
 }
 
-_racket_self_test 'raco scribble:611326287'
+_racket_self_test 'raco scribble:313127162'
 _raco_cmd_scribble() {
+  local exclusive_modes='(--html --htmls --html-tree --latex --pdf --xelatex --lualatex --dvipdf --latex-section --text --markdown)'
   _arguments "$RACKET_COMMON[@]" \
-    '(--html --htmls --latex --pdf --latex-section --text --markdown)'--html'[Generate HTML-format output file (default)]' \
-    '(--html --htmls --latex --pdf --latex-section --text --markdown)'--htmls'[Generate HTML-format output directory]' \
-    '(--html --htmls --latex --pdf --latex-section --text --markdown)'--pdf'[Generate PDF-format output (with PDFLaTeX)]' \
-    '(--html --htmls --latex --pdf --latex-section --text --markdown)'--latex'[Generate LaTeX-format output]' \
-    '(--html --htmls --latex --pdf --latex-section --text --markdown)'--latex-section'+[Generate LaTeX-format output for section depth N]:section-depth: ' \
-    '(--html --htmls --latex --pdf --latex-section --text --markdown)'--text'[Generate text-format output]' \
-    '(--html --htmls --latex --pdf --latex-section --text --markdown)'--markdown'[Generate markdown-format output]' \
-    '(--dest)'--dest'+[Write output in directory]:directory:_files -/' \
-    '(--dest-name)'--dest-name'+[Write output as name]:name: ' \
-    '(--dest-base)'--dest-base'+[Start support-file names with prefix]:prefix: ' \
-    '*'++style'+[Add given .css/.tex file after others]:style-file:_files -g \*.\(css\|tex\)' \
-    '*'--style'+[Use given base .css/.tex file]:style-file:_files -g \*.\(css\|tex\)' \
-    '*'--prefix'+[Use given .html/.tex prefix (for doctype/documentclass)]:prefix-file:_files -g \*.\(html\|htm\|tex\)' \
-    '*'++extra'+[Add given file]:file:_files' \
-    '*'--redirect-main'+[Redirect main doc links to url]:url: ' \
-    '*'--redirect'+[Redirect external links to tag search via url]:url: ' \
+    "$exclusive_modes"--html'[Generate HTML-format output file (default)]' \
+    "$exclusive_modes"--htmls'[Generate HTML-format output directory]' \
+    "$exclusive_modes"--html-tree'[Generate HTML-format output directories N deep]:section-depth: ' \
+    "$exclusive_modes"--latex'[Generate LaTeX-format output]' \
+    "$exclusive_modes"--pdf'[Generate PDF-format output (via PDFLaTeX)]' \
+    "$exclusive_modes"--xelatex'[Generate PDF-format output (via XeLaTeX)]' \
+    "$exclusive_modes"--lualatex'[Generate PDF-format output (via LuaLaTeX)]' \
+    "$exclusive_modes"--dvipdf'[Generate PDF-format output (via LaTeX, dvips, and pstopdf)]' \
+    "$exclusive_modes"--latex-section'[Generate LaTeX-format output for section depth N]:section-depth: ' \
+    "$exclusive_modes"--text'[Generate text-format output]' \
+    "$exclusive_mods"--markdown'[Generate markdown-format output]' \
+    '(--lib -l)'{--lib,-l}'[Treat argument as library paths instead of filesystem paths]:*:lib-file:->libfile' \
+    '(--dest)'--dest'[Write output in directory]:directory:_files -/' \
+    '(--dest-name)'--dest-name'[Write output as name]:name: ' \
+    '(--dest-base)'--dest-base'[Start support-file names with prefix]:prefix: ' \
+    '(--keep-at-dest-base)'--keep-at-dest-base'[Keep existing files at location of support files]' \
+    '*'++convert'[Prefer image conversion to format]:format:(ps pdf svg png gif)' \
+    '*'++style'[Add given .css/.tex file after others]:style-file:_files -g \*.\(css\|tex\)' \
+    '(--style)'--style'[Use given base .css/.tex file]:style-file:_files -g \*.\(css\|tex\)' \
+    '(--prefix)'--prefix'[Use given .html/.tex prefix (for doctype/documentclass)]:prefix-file:_files -g \*.\(html\|htm\|tex\)' \
+    '(--link-section)'--link-section'[Support section links for markdown]' \
+    '*'++extra'[Add given file]:file:_files' \
+    '*'--redirect-main'[Redirect main doc links to url]:url: ' \
+    '*'--redirect'[Redirect external links to tag search via url]:url: ' \
     '(+m ++main-xref-in)'{+m,++main-xref-in}'[load format-speficic cross-ref info for all installed library collections]' \
-    '*'++xref-in'+[Load format-specific cross-ref info by]:module-path:->libfile:proc-id: ' \
-    '*'--info-out'+[Write format-specific cross-ref info to file]:file:_file' \
-    '*'++info-in'+[Load format-specific cross-ref info from file]:file:_file' \
+    '*'++xref-in'[Load format-specific cross-ref info by]:module-path:->libfile:proc-id: ' \
+    '*'--info-out'[Write format-specific cross-ref info to file]:file:_files' \
+    '*'++info-in'[Load format-specific cross-ref info from file]:file:_files' \
+    '*'++arg'[Add argument to current-command-line-arguments]:argument: ' \
     '(--quiet)'--quiet'[Suppress output-file and undefined-tag reporting]' \
+    '(--doc-binding)'--doc-binding'[Render document provided as ID instead of `doc'\'']:doc-binding: ' \
+    '(--make -y)'{--make,-y}'[Enable automatic update of compiled files]' \
+    '(--errortrace)'--errortrace'[Enable errortrace]' \
     '*:scribble-file:_files -g \*.scrbl' \
   && return 0
   _racket_do_state

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -559,6 +559,51 @@ _raco_cmd_pkg() {
   fi
 }
 
+_racket_self_test 'raco pkg install:2252657386'
+_raco_cmd_pkg_install() {
+  local specs=(
+    '(-t --type)'{-t,--type}'[Specify type of source, instead of inferred]:type:(file dir file-url dir-url git git-url github name)'
+    '(-n --name)'{-n,--name}'[Specify name of package, instead of inferred; makes sense only when a single pkg-source is given]:name: '
+    '(--checksum)'--checksum'[Checksum of package, either expected or selected; makes sense only when a single pkg-source is given]:checksum: '
+    '(--deps --auto)'--deps'[Specify the behavior for uninstalled dependencies]:mode:(fail force search-ask search-auto)'
+    '(--deps --auto)'--auto'[Shorthand for `--deps search-auto'\'']'
+    '(--update-deps)'--update-deps'[For `search-ask'\'' or `search-auto'\'', also update dependencies]'
+    '(--ignore-implies)'--ignore-implies'[When updating, treat `implies'\'' like other dependencies]'
+    '(--link --static-link --copy --clone --source --binary --binary-lib)'--link'[Link a directory package source in place (default for a directory)]'
+    '(--link --static-link --copy --clone --source --binary --binary-lib)'--static-link'[Link in place, promising collections do not change]'
+    '(--link --static-link --copy --clone --source --binary --binary-lib)'--copy'[Treat directory sources the same as other sources]'
+    '(--link --static-link --copy --clone --source --binary --binary-lib)'--clone'[Clone Git and GitHub package sources and link]:clone directory: '
+    '(--link --static-link --copy --clone --source --binary --binary-lib)'--source'[Strip packages'\'' built elements before installing; implies --copy]'
+    '(--link --static-link --copy --clone --source --binary --binary-lib)'--binary'[Strip packages'\'' source elements before installing; implies --copy]'
+    '(--link --static-link --copy --clone --source --binary --binary-lib)'--binary-lib'[Strip source & documentation before installing; implies --copy]'
+    '(--scope -i --installation -u --user --scope-dir)'--scope'[Select package scope]:scope:(installation user)'
+    '(--scope -i --installation -u --user --scope-dir)'{-i,--installation}'[Shorthand for `--scope installation'\'']'
+    '(--scope -i --installation -u --user --scope-dir)'{-u,--user}'[Shorthand for `--scope user'\'']'
+    '(--scope -i --installation -u --user --scope-dir)'--scope-dir'[Select package scope <dir>]:scope:_files -/'
+    '*'--catalog'[Use instead of configured catalogs]:catalog: '
+    '(--skip-installed)'--skip-installed'[Skip a pkg-source if already installed]'
+    '(--pkgs)'--pkgs'[Install only the specified packages, even when none are provided]'
+    '(--all-platforms)'--all-platforms'[Follow package dependencies for all platforms]'
+    '(--force)'--force'[Ignore conflicts]'
+    '(--ignore-checksums)'--ignore-checksums'[Ignore checksums]'
+    '(--strict-doc-conflicts)'--strict-doc-conflicts'[Report doc-name conflicts, even for user scope]'
+    '(--no-cache)'--no-cache'[Disable download cache]'
+    '(--multi-clone)'--multi-clone'[Specify treatment of multiple clones of a repository]:mode:(convert ask fail force)'
+    '(--pull)'--pull'[Specify `git pull'\'' mode for repository clones]:mode:(ff-only try rebase)'
+    '(--dry-run)'--dry-run'[Don'\''t actually change package installation]'
+    '(--no-setup)'--no-setup'[Don'\''t `raco setup` after changing packages (usually a bad idea)]'
+    '(-D --no-docs)'{-D,--no-docs}'[Do not compile .scrbl files and do not build documentation]'
+    '(--recompile-only)'--recompile-only'[Expect built packages, possibly machine-independent]'
+    '(-j --jobs)'{-j,--jobs}'[Setup with N parallel jobs]:cores: '
+    '(--batch)'--batch'[Disable interactive mode and all prompts]'
+    '(--no-trash)'--no-trash'[Delete uninstalled/updated, instead of moving to a trash folder]'
+    '(--fail-fast)'--fail-fast'[Break `raco setup'\'' when it discovers an error]'
+    '*:package source: '
+  )
+  _arguments "$RACKET_COMMON[@]" "$specs[@]" && return 0
+  _racket_do_state
+}
+
 _racket_self_test 'raco planet:1582997403'
 _raco_cmd_planet() {
   if (( CURRENT > 2 )); then

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -229,11 +229,11 @@ _raco_cmd_setup() {
     '(-p --pause)'{-p,--pause}'[Pause at the end if there are any errors]' \
     '(--force)'--force'[Treat version mismatches for archives as mere warnings]' \
     '(-a --all-users)'{-a,--all-users}'[Install archives to main (not user-specific) installation]' \
-    '(--mode)'--mode'+[Select a compilation mode]:log-level:(errortrace)' \
-    '(--doc-pdf)'--doc-pdf'+[Write doc PDF to directory]:directory:_files -/' \
-    '(-l)'-l'+[Setup specific collections only]:*:collection:->collect' \
-    '(-A)'-A'+[Unpack and install .plt archives]:plt-archive:_files -g \*.plt' \
-    '*'-P'+[Setup specified PLaneT packages only]:owner: :package-name: :major-version: :minor-version: ' \
+    '(--mode)'--mode'[Select a compilation mode]:log-level:(errortrace)' \
+    '(--doc-pdf)'--doc-pdf'[Write doc PDF to directory]:directory:_files -/' \
+    '(-l)'-l'[Setup specific collections]:*:collection:->collect' \
+    '(-A)'-A'[Unpack and install .plt archives]:plt-archive:_files -g \*.plt' \
+    '*'-P'[Setup specified PLaneT packages only]:owner: :package-name: :major-version: :minor-version: ' \
   && return 0
   _racket_do_state
 }

--- a/racket-completion.zsh
+++ b/racket-completion.zsh
@@ -593,14 +593,14 @@ COMMON_PKG_ARGS=(
   '(--recompile-only)'--recompile-only'[Expect built packages, possibly machine-independent]'
   '(-j --jobs)'{-j,--jobs}'[Setup with N parallel jobs]:cores: '
   '(--batch)'--batch'[Disable interactive mode and all prompts]'
+  '(--deps --auto)'--deps'[Specify the behavior for uninstalled dependencies]:mode:(fail force search-ask search-auto)'
+  '(--deps --auto)'--auto'[Shorthand for `--deps search-auto'\'']'
 )
 
 INSTALL_UPDATE_ARGS=(
   '(-t --type)'{-t,--type}'[Specify type of source, instead of inferred]:type:(file dir file-url dir-url git git-url github name)'
   '(-n --name)'{-n,--name}'[Specify name of package, instead of inferred; makes sense only when a single pkg-source is given]:name: '
   '(--checksum)'--checksum'[Checksum of package, either expected or selected; makes sense only when a single pkg-source is given]:checksum: '
-  '(--deps --auto)'--deps'[Specify the behavior for uninstalled dependencies]:mode:(fail force search-ask search-auto)'
-  '(--deps --auto)'--auto'[Shorthand for `--deps search-auto'\'']'
   '(--update-deps)'--update-deps'[For `search-ask'\'' or `search-auto'\'', also update dependencies]'
   '(--ignore-implies)'--ignore-implies'[When updating, treat `implies'\'' like other dependencies]'
   '(--multi-clone)'--multi-clone'[Specify treatment of multiple clones of a repository]:mode:(convert ask fail force)'
@@ -702,7 +702,6 @@ _raco_cmd_pkg_show() {
 _racket_self_test 'raco pkg migrate:2132316292'
 _raco_cmd_pkg_migrate() {
   local specs=(
-    '(--deps)'--deps'[Specify the behavior for uninstalled dependencies]:mode:(fail force search-ask search-auto)'
     '(--source --binary --binary-lib)'--source'[Strip built elements of the package before installing]'
     '(--binary --binary --binary-lib)'--binary'[Strip source elements of the package before installing]'
     '(--binary-lib --binary --binary-lib)'--binary-lib'[Strip source elements and documentation before installing]'


### PR DESCRIPTION
I updated or added the completion code for the commands I use (since those were the ones I could best evaluated).

Further notes:
- I tried to keep each patch small, so the aggregate may look large but should be reviewable in pieces.
- I didn't update raco's checksum because I have non-standard tools installed that would change the correct checksum.
- For extremely simple completions, the following Vim macro can turn the help text (two lines of `--arg` and `description`) into an `_arguments` argument (depends on [surround](https://github.com/tpope/vim-surround); provides a decent starting point for many complex completions):
    ```
    yypkyssbyss'Jxjyss]yss'kJxj
    ```
- I'm willing to drop the (almost tip) commit 7d05838 (todo: note a problem with top-level collections, 2024-11-26), but I noticed a problem and don't have a good suggestion (yet) on how to fix it. I figured I'd share the information I learned while playing with the code.

Suggestions for improvement welcome, particularly to remove almost-but-not-quite-duplicate code or the post-processing on `raco pkg show` output.
